### PR TITLE
[SPARK-8939] [EC2] YARN EC2 default setting fails with IllegalArgumentException

### DIFF
--- a/templates/root/spark/conf/spark-env.sh
+++ b/templates/root/spark/conf/spark-env.sh
@@ -4,7 +4,7 @@ export SPARK_LOCAL_DIRS="{{spark_local_dirs}}"
 
 # Standalone cluster options
 export SPARK_MASTER_OPTS="{{spark_master_opts}}"
-if [ -n {{spark_worker_instances}} ]; then
+if [ -n "{{spark_worker_instances}}" ]; then
   export SPARK_WORKER_INSTANCES={{spark_worker_instances}}
 fi
 export SPARK_WORKER_CORES={{spark_worker_cores}}


### PR DESCRIPTION
Surround `{{spark_worker_instances}}` with quotes for the replacement for YARN results into

```
if [ -n "" ]; then
  export SPARK_WORKER_INSTANCES=
fi
```

rather than

```
if [ -n  ]; then
  export SPARK_WORKER_INSTANCES=
fi
```

Currently the if statement evaluate to true and set `SPARK_WORKER_INSTANCES` to empty string, which is picked up by https://github.com/apache/spark/blob/v1.5.0/core/src/main/scala/org/apache/spark/SparkConf.scala#L481 causing the driver to throw following exception

```
15/09/15 03:14:06 WARN SparkConf: 
SPARK_WORKER_INSTANCES was detected (set to '').
This is deprecated in Spark 1.0+.
```

and

```
15/07/09 03:44:29 ERROR SparkContext: Error initializing SparkContext.
java.lang.IllegalArgumentException: Unknown/unsupported param List(--num-executors, , --executor-memory, 6154m, --executor-memory, 6154m, --executor-cores, 2, --name, Spark shell)
```
