### PR TITLE
Fix hadoop native library collision in YARN

### DIFF
--- a/ephemeral-hdfs/init.sh
+++ b/ephemeral-hdfs/init.sh
@@ -15,6 +15,7 @@ case "$HADOOP_MAJOR_VERSION" in
     rm hadoop-*.tar.gz
     mv hadoop-1.0.4/ ephemeral-hdfs/
     sed -i 's/-jvm server/-server/g' /root/ephemeral-hdfs/bin/hadoop
+    cp /root/hadoop-native/* /root/ephemeral-hdfs/lib/native/
     ;;
   2) 
     wget http://s3.amazonaws.com/spark-related-packages/hadoop-2.0.0-cdh4.2.0.tar.gz  
@@ -26,6 +27,7 @@ case "$HADOOP_MAJOR_VERSION" in
     # Have single conf dir
     rm -rf /root/ephemeral-hdfs/etc/hadoop/
     ln -s /root/ephemeral-hdfs/conf /root/ephemeral-hdfs/etc/hadoop
+    cp /root/hadoop-native/* /root/ephemeral-hdfs/lib/native/
     ;;
   yarn)
     wget http://s3.amazonaws.com/spark-related-packages/hadoop-2.4.0.tar.gz
@@ -43,7 +45,6 @@ case "$HADOOP_MAJOR_VERSION" in
      echo "ERROR: Unknown Hadoop version"
      return 1
 esac
-cp /root/hadoop-native/* ephemeral-hdfs/lib/native/
 /root/spark-ec2/copy-dir /root/ephemeral-hdfs
 
 popd > /dev/null

--- a/persistent-hdfs/init.sh
+++ b/persistent-hdfs/init.sh
@@ -14,6 +14,7 @@ case "$HADOOP_MAJOR_VERSION" in
     tar xvzf hadoop-1.0.4.tar.gz > /tmp/spark-ec2_hadoop.log
     rm hadoop-*.tar.gz
     mv hadoop-1.0.4/ persistent-hdfs/
+    cp /root/hadoop-native/* /root/persistent-hdfs/lib/native/
     ;;
   2)
     wget http://s3.amazonaws.com/spark-related-packages/hadoop-2.0.0-cdh4.2.0.tar.gz
@@ -25,6 +26,7 @@ case "$HADOOP_MAJOR_VERSION" in
     # Have single conf dir
     rm -rf /root/persistent-hdfs/etc/hadoop/
     ln -s /root/persistent-hdfs/conf /root/persistent-hdfs/etc/hadoop
+    cp /root/hadoop-native/* /root/persistent-hdfs/lib/native/
     ;;
   yarn)
     wget http://s3.amazonaws.com/spark-related-packages/hadoop-2.4.0.tar.gz
@@ -42,7 +44,6 @@ case "$HADOOP_MAJOR_VERSION" in
      echo "ERROR: Unknown Hadoop version"
      return 1
 esac
-cp /root/hadoop-native/* /root/persistent-hdfs/lib/native/
 /root/spark-ec2/copy-dir /root/persistent-hdfs
 
 popd > /dev/null


### PR DESCRIPTION
When installing Spark EC2 with hadoop version `"yarn"`, Hadoop 2.4.0 is installed. The installed hadoop distribution[1] already contains native hadoop library files.

But the `ephemeral-hdfs/init.sh` and `persistent-hdfs/init.sh` scripts overwrite the native library files with files from `/root/hadoop-native/`. But Hadoop 2.4.0 and the library binaries in `/root/hadoop-native` are not compatible. This causes following errors on Spark initialization:

```
java.lang.UnsatisfiedLinkError: org.apache.hadoop.security.JniBasedUnixGroupsMapping.anchorNative()V
at org.apache.hadoop.security.JniBasedUnixGroupsMapping.anchorNative(Native Method)
```

This patch solves this problem by only copying native libraries when the Hadoop version is "1" or "2".

[1]: http://s3.amazonaws.com/spark-related-packages/hadoop-2.4.0.tar.gz

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/amplab/spark-ec2/11)

<!-- Reviewable:end -->
