### PR TITLE
fix broken link to spark_ec2.py in spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ and can be used to install any pre-requisites.
    after the templates have been configured. You can use the environment variables `$SLAVES` to
    get a list of slave hostnames and `/root/spark-ec2/copy-dir` to sync a directory across machines.
       
-   e. Modify https://github.com/mesos/spark/blob/master/ec2/spark_ec2.py to add your module to
+   e. Modify spark_ec2.py located somewhere in https://github.com/mesos/spark-ec2 to add your module to
    the list of enabled modules.


### PR DESCRIPTION
If you know correct full link to spark_ec2.py in mesos/spark-ec2 or amplab let me know I'll update the PR
