### PR TITLE
Moves from optparse to argparse

### DIFF
--- a/spark_ec2.py
+++ b/spark_ec2.py
@@ -180,6 +180,8 @@ def parse_args():
 
     # Optional arguments
     parser.add_argument(
+        "--version", action="version", version="%(prog)s {v}".format(v=SPARK_EC2_VERSION))
+    parser.add_argument(
         "-s", "--slaves", type=int, default=1,
         help="Number of slaves to launch (default: %(default)s)")
     parser.add_argument(


### PR DESCRIPTION
See https://docs.python.org/2.7/library/argparse.html#upgrading-optparse-code for a checklist of things that should have been done (which I tried to follow), and http://stackoverflow.com/questions/3217673/why-use-argparse-rather-than-optparse for a discussion of why this is a good idea in general.
