### PR TITLE
s3a filesystem added to core-site for ephemeral-hdfs and persistent-hdfs

### DIFF
--- a/templates/root/ephemeral-hdfs/conf/core-site.xml
+++ b/templates/root/ephemeral-hdfs/conf/core-site.xml
@@ -61,6 +61,21 @@
   </property>
 
   <property>
+    <name>fs.s3a.impl</name>
+    <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.access.key</name>
+    <value>{{aws_access_key_id}}</value>
+  </property>
+  
+  <property>
+    <name>fs.s3a.secret.key</name>
+    <value>{{aws_secret_access_key}}</value>
+  </property>
+
+  <property>
     <name>hadoop.security.group.mapping</name>
     <value>org.apache.hadoop.security.ShellBasedUnixGroupsMapping</value>
   </property>

--- a/templates/root/persistent-hdfs/conf/core-site.xml
+++ b/templates/root/persistent-hdfs/conf/core-site.xml
@@ -61,6 +61,21 @@
   </property>
 
   <property>
+    <name>fs.s3a.impl</name>
+    <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.access.key</name>
+    <value>{{aws_access_key_id}}</value>
+  </property>
+  
+  <property>
+    <name>fs.s3a.secret.key</name>
+    <value>{{aws_secret_access_key}}</value>
+  </property>
+
+  <property>
     <name>hadoop.security.group.mapping</name>
     <value>org.apache.hadoop.security.ShellBasedUnixGroupsMapping</value>
   </property>


### PR DESCRIPTION
s3a is the successor of s3n file system, s3a offers higher performance and support of larger files.
For more details: [https://wiki.apache.org/hadoop/AmazonS3](https://wiki.apache.org/hadoop/AmazonS3)
