### PR TITLE
change default instance from m1.large to m3.large

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ following options are worth pointing out:
 
 -   `--instance-type=<instance-type>` can be used to specify an EC2
 instance type to use. For now, the script only supports 64-bit instance
-types, and the default type is `m1.large` (which has 2 cores and 7.5 GB
+types, and the default type is `m3.large` (which has 2 cores and 7.5 GB
 RAM). Refer to the Amazon pages about [EC2 instance
 types](http://aws.amazon.com/ec2/instance-types) and [EC2
 pricing](http://aws.amazon.com/ec2/#pricing) for information about other

--- a/spark_ec2.py
+++ b/spark_ec2.py
@@ -192,7 +192,7 @@ def parse_args():
         help="If you have multiple profiles (AWS or boto config), you can configure " +
              "additional, named profiles by using this option (default: %default)")
     parser.add_option(
-        "-t", "--instance-type", default="m1.large",
+        "-t", "--instance-type", default="m3.large",
         help="Type of instance to launch (default: %default). " +
              "WARNING: must be 64-bit; small instances won't work")
     parser.add_option(


### PR DESCRIPTION
While setting up a spark cluster on EC2, noticed that the default instance type was m1.large

This type is considered previous generation and has better alternatives.
http://aws.amazon.com/ec2/previous-generation/

quoting amazon's documentation:

> M3 instances provide better, more consistent performance than M1 instances for most use-cases. 
> M3 instances also offer SSD-backed instance storage that delivers higher I/O performance. 
> **M3 instances are also less expensive than M1 instances.** Due to these reasons, we recommend M3 for applications that require general purpose instances with a balance of compute, memory, and network resources.

I've just replaced the default value type in the respective python script and updated the Read me;
this is my first pull request to this repo. If I've missed something please let me know.

Thanks!
