### PR TITLE
Config file devel

### DIFF
--- a/keys/README.md
+++ b/keys/README.md
@@ -1,0 +1,1 @@
+This folder contains the identity files.

--- a/keys/README.md
+++ b/keys/README.md
@@ -1,1 +1,0 @@
-This folder contains the identity files.

--- a/spark_ec2.py
+++ b/spark_ec2.py
@@ -216,10 +216,10 @@ def process_conf_file(file_path, parser):
     [map_conf.update(mapping_conf(opt)) for opt in parser.option_list]
     [map_conf.pop(unneeded_opt, None) for unneeded_opt in unneeded_opts]
 
-    # Path to identity file (located in keys folder under current location of spark-ec2 file)
-    configuration["identity_file"] = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                  "keys",
-                                                  configuration["identity_file"])
+    # Generating path to identity file (located in ~/.ssh/)
+    home_dir = os.path.expanduser('~')
+    key_pair_path = os.path.join(home_dir, ".ssh", configuration["identity_file"])
+    configuration["identity_file"] = key_pair_path
 
     # Setting credentials to the environment to access AWS.
     if "credentials" in configuration:

--- a/spark_ec2.py
+++ b/spark_ec2.py
@@ -183,9 +183,9 @@ def process_conf_file(file_path, parser, opts):
         with open(file_path) as configuration_file:
             configuration = json.load(configuration_file)
     except Exception as e:
-        err_msg = " ".join(map(str, e.args))
+        err_msg = " ".join([str(err) for err in e.args])
         print("[!] Error when loading config file: {}".format(err_msg), file=stderr)
-        sys.exit(-1)
+        sys.exit(1)
 
     JSON_SPECIAL_PARAMS = {
         "no_ganglia": "--no-ganglia",
@@ -423,13 +423,14 @@ def parse_args():
                         help="Specify config file", metavar="FILE")
 
     (opts, args) = parser.parse_args()
-    if opts.conf_file:
-        opts = process_conf_file(opts.conf_file, parser, opts)
 
     if len(args) != 2:
         parser.print_help()
         sys.exit(1)
     (action, cluster_name) = args
+
+    if opts.conf_file:
+        opts = process_conf_file(opts.conf_file, parser, opts)
 
     # Boto config check
     # http://boto.cloudhackers.com/en/latest/boto_config_tut.html


### PR DESCRIPTION
# Configuration file

`-c` or `--conf-file` option enables to use a YAML configuration file to simplify the way you interact with the cluster.
## Launch new cluster

`./spark-ec2 --conf-file config.yml launch my_cluster`
## Example of a configuration file

``` yml
slaves: 2
instance_type: r3.xlarge
region: eu-west-1
zone: eu-west-1c
ami: ami-xxxxxxxx
spot_price: 0.07
hadoop_major_version: yarn

spark_ec2_git_repo: https://github.com/tirami-su/spark-ec2
spark_ec2_git_branch: config_file-devel

copy_aws_credentials: true
no_ganglia: y
resume: on

## Network and security
key_pair: xxxxx
identity_file: xxxxx.pem

credentials: 
   aws_access_key_id: XXXXX
   aws_secret_access_key: XXXXX
```
## Note
- In this version, when  `-c` or `--config-file` option is precised, only the parameters present in the configuration file are used. If there is other options in the command line, they are ignored.
- The identity file must be located in `~/.ssh/`.
## Modificaiton

JSON to YAML
Keys must be located in `~/.ssh/`
