### PR TITLE
This pull request makes newer Spark versions with yarn use Hadoop 2.7.

### DIFF
--- a/spark/init.sh
+++ b/spark/init.sh
@@ -130,7 +130,7 @@ else
       elif [[ "$HADOOP_MAJOR_VERSION" == "2" ]]; then
         wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-bin-cdh4.tgz
       else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-bin-hadoop2.4.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-bin-hadoop2.7.tgz
       fi
       if [ $? != 0 ]; then
         echo "ERROR: Unknown Spark version"


### PR DESCRIPTION
This pull request makes newer Spark versions with yarn use Hadoop 2.7. The purpose is to make it possible to use the s3a filesystem scheme with spark-ec2 Amazon EC2 deployments.