### PR TITLE
Add README note about project status and recommended alternative

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,1 @@
+spark-ec2 is no longer in active development. Please refer to the README.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,1 @@
+spark-ec2 is no longer in active development. Please refer to the README.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+_Please note: spark-ec2 is **no longer under active development**. If you're looking for a similar tool that is under active development, we recommend you take a look at [Flintrock](https://github.com/nchammas/flintrock)._
+
 # EC2 Cluster Setup for Apache Spark
 
 `spark-ec2` allows you


### PR DESCRIPTION
spark-ec2 is no longer under active development. This has been the reality for about a year or so, but I have been asked by @shivaram to submit a PR making this official by adding a note to the README and redirecting people to [Flintrock](https://github.com/nchammas/flintrock), a project I created as a sort of spiritual successor to spark-ec2.

I think @shivaram can provide a proper post-mortem on his end for why spark-ec2 development has effectively stalled. From my perspective, I believe the main reasons are:
* spark-ec2's dependence on custom AMIs makes it difficult for the project to keep up pace with Spark itself. This is a problem I tried unsuccessfully to tackle for spark-ec2 [years ago](https://issues.apache.org/jira/browse/SPARK-3821) and have [discussed here as well](https://github.com/amplab/spark-ec2/issues/74#issuecomment-261123683).
* Major improvements to spark-ec2's user experience (launch speed, persistent configs) require a lot of review time, and the core people on this project (mainly @shivaram these days, myself and others to a lesser degree) don't have the bandwidth to keep up.

Flintrock addresses these key issues -- they were, in fact, the main [motivation](https://github.com/nchammas/flintrock#motivation) for the project -- and I'd be happy to help onboard users who decide to switch from spark-ec2 to Flintrock.